### PR TITLE
Support strapi 4.10.7+

### DIFF
--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -5,7 +5,10 @@ module.exports = ({ strapi }) => {
   // Subscribe to the lifecycles that we are intrested in.
   strapi.db.lifecycles.subscribe((event) => {
     if (event.action === 'beforeFindMany' || event.action === 'beforeFindOne') {
-      const populate = event.params?.populate;
+      let populate = event.params?.populate;
+      if (typeof populate === 'string') {
+        populate = [populate]
+      }
       const defaultDepth = strapi.plugin('strapi-plugin-populate-deep')?.config('defaultDepth') || 5
 
       if (populate && populate[0] === 'deep') {


### PR DESCRIPTION
There might be a cleaner solution but it seems like since strapi v4.10.7, the event parameter is passed as a string `deep`, rather than an array `[deep]`.

This should be backwards compatible, tested locally on 4.10.7 and 4.11.0