### PR TITLE
fix: deep assign populated objects

### DIFF
--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -1,4 +1,20 @@
-const { isEmpty, merge } = require("lodash/fp");
+const { isEmpty } = require("lodash/fp");
+
+const deepAssign = (target, source) => {
+    for (const key in source) {
+      if (Object.prototype.hasOwnProperty.call(source, key)) {
+        if (typeof source[key] === 'object' && source[key] !== null) {
+          if (!target[key] || typeof target[key] !== 'object' || target[key] === null) {
+            target[key] = source[key];
+          }
+          deepAssign(target[key], source[key]);
+        } else if (!target[key] || typeof target[key] !== 'object' || target[key] === null) {
+          target[key] = source[key];
+        }
+      }
+    }
+    return target;
+}
 
 const getModelPopulationAttributes = (model) => {
   if (model.uid === "plugin::upload.file") {
@@ -32,7 +48,7 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
       } else if (value.type === "dynamiczone") {
         const dynamicPopulate = value.components.reduce((prev, cur) => {
           const curPopulate = getFullPopulateObject(cur, maxDepth - 1);
-          return curPopulate === true ? prev : merge(prev, curPopulate);
+          return curPopulate === true ? prev : deepAssign(prev, curPopulate);
         }, {});
         populate[key] = isEmpty(dynamicPopulate) ? true : dynamicPopulate;
       } else if (value.type === "relation") {


### PR DESCRIPTION
Current implementation of `getFullPopulateObject` doesn't merge objects from different dynamic zones deeply. 

If you try to merge objects with lodash, it'll merge them shallowly, so booleans have higher priority than objects when passed as second argument. This can result into bugs described in #42, #41.
Can be reproduced with code `merge({ a: { b: true } }, { a: true })`, which results to `{ a: true }`

Following code will make objects prioritised above boolean, so result of `deepAssign({ a: { b: true } }, { a: true })` is `{ a: { b: true } }`.