### PR TITLE
Add skipLocalizationsFields config value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "strapi-plugin-populate-deep",
-  "version": "2.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-populate-deep",
-  "version": "2.0.0",
+  "version": "3.1.0",
   "description": "Strapi plugin that populates nested content.",
   "strapi": {
     "name": "strapi-plugin-populate-deep",

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -1,17 +1,20 @@
 'use strict';
-const { getFullPopulateObject } = require('./helpers')
+const { getFullPopulateObject } = require('./helpers');
 
 module.exports = ({ strapi }) => {
   // Subscribe to the lifecycles that we are intrested in.
   strapi.db.lifecycles.subscribe((event) => {
     if (event.action === 'beforeFindMany' || event.action === 'beforeFindOne') {
       const populate = event.params?.populate;
-      const defaultDepth = strapi.plugin('strapi-plugin-populate-deep')?.config('defaultDepth') || 5
 
       if (populate && populate[0] === 'deep') {
-        const depth = populate[1] ?? defaultDepth
-        const modelObject = getFullPopulateObject(event.model.uid, depth, []);
-        event.params.populate = modelObject.populate
+        const defaultDepth = strapi.plugin('strapi-plugin-populate-deep')?.config('defaultDepth') || 5;
+        const skipLocalizationsFields = strapi.plugin('strapi-plugin-populate-deep')?.config('skipLocalizationsFields');
+
+        const depth = populate[1] ?? defaultDepth;
+        const ignore = skipLocalizationsFields ? ['localizations'] : [];
+        const modelObject = getFullPopulateObject(event.model.uid, depth, ignore);
+        event.params.populate = modelObject.populate;
       }
     }
   });

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -4,6 +4,7 @@ module.exports = {
   default: {
     defaultDepth: 5,
     skipCreatorFields: true,
+    skipLocalizationsFields: false,
   },
   validator: () => { },
 };

--- a/server/index.js
+++ b/server/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const bootstrap = require('./bootstrap');
-const config = require('./config')
+const config = require('./config');
 
 module.exports = {
   bootstrap,


### PR DESCRIPTION
When using [i18n plugin](https://docs.strapi.io/dev-docs/plugins/i18n) `populate=deep` results in populating `'localizations'` field which is not always desirable. This PR allows to skip localizations population.