### PR TITLE
fix: deep assign populated objects

### DIFF
--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -1,4 +1,28 @@
-const { isEmpty, merge } = require("lodash/fp");
+const { isEmpty } = require("lodash/fp");
+
+const deepAssign = (target, source) => {
+  for (const key in source) {
+    if (Object.prototype.hasOwnProperty.call(source, key)) {
+      if (typeof source[key] === "object" && source[key] !== null) {
+        if (
+          !target[key] ||
+          typeof target[key] !== "object" ||
+          target[key] === null
+        ) {
+          target[key] = source[key];
+        }
+        deepAssign(target[key], source[key]);
+      } else if (
+        !target[key] ||
+        typeof target[key] !== "object" ||
+        target[key] === null
+      ) {
+        target[key] = source[key];
+      }
+    }
+  }
+  return target;
+};
 
 const getModelPopulationAttributes = (model) => {
   if (model.uid === "plugin::upload.file") {
@@ -10,7 +34,9 @@ const getModelPopulationAttributes = (model) => {
 };
 
 const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
-  const skipCreatorFields = strapi.plugin('strapi-plugin-populate-deep')?.config('skipCreatorFields');
+  const skipCreatorFields = strapi
+    .plugin("strapi-plugin-populate-deep")
+    ?.config("skipCreatorFields");
 
   if (maxDepth <= 1) {
     return true;
@@ -21,24 +47,25 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
 
   const populate = {};
   const model = strapi.getModel(modelUid);
-  if (ignore && !ignore.includes(model.collectionName)) ignore.push(model.collectionName)
+  if (ignore && !ignore.includes(model.collectionName))
+    ignore.push(model.collectionName);
   for (const [key, value] of Object.entries(
     getModelPopulationAttributes(model)
   )) {
-    if (ignore?.includes(key)) continue
+    if (ignore?.includes(key) || value.private === true) continue;
     if (value) {
       if (value.type === "component") {
         populate[key] = getFullPopulateObject(value.component, maxDepth - 1);
       } else if (value.type === "dynamiczone") {
         const dynamicPopulate = value.components.reduce((prev, cur) => {
           const curPopulate = getFullPopulateObject(cur, maxDepth - 1);
-          return curPopulate === true ? prev : merge(prev, curPopulate);
+          return curPopulate === true ? prev : deepAssign(prev, curPopulate);
         }, {});
         populate[key] = isEmpty(dynamicPopulate) ? true : dynamicPopulate;
       } else if (value.type === "relation") {
         const relationPopulate = getFullPopulateObject(
           value.target,
-          (key === 'localizations') && maxDepth > 2 ? 1 : maxDepth - 1,
+          key === "localizations" && maxDepth > 2 ? 1 : maxDepth - 1,
           ignore
         );
         if (relationPopulate) {
@@ -53,5 +80,5 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
 };
 
 module.exports = {
-  getFullPopulateObject
-}
+  getFullPopulateObject,
+};


### PR DESCRIPTION
copy of https://github.com/Barelydead/strapi-plugin-populate-deep/pull/43 on the original plugin, since the issue still presists

Current implementation of getFullPopulateObject doesn't merge objects from different dynamic zones deeply.

If you try to merge objects with lodash, it'll merge them shallowly, so booleans have higher priority than objects when passed as second argument. This can result into bugs described in https://github.com/Barelydead/strapi-plugin-populate-deep/issues/42, https://github.com/Barelydead/strapi-plugin-populate-deep/issues/41.
Can be reproduced with code merge({ a: { b: true } }, { a: true }), which results to { a: true }

Following code will make objects prioritised above boolean, so result of deepAssign({ a: { b: true } }, { a: true }) is { a: { b: true } }.