### PR TITLE
Fix/localizations-not-populated

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: https://registry.npmjs.org/
 
       - name: Check if version already on npm
         id: check
@@ -31,4 +32,8 @@ jobs:
 
       - name: Publish
         if: steps.check.outputs.exists == 'false'
-        run: npm publish --provenance --access public
+        run: |
+          unset NODE_AUTH_TOKEN
+          npm config delete //registry.npmjs.org/:_authToken || true
+          npm config delete always-auth || true
+          npm publish --provenance --access public

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,8 +17,11 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
+
+      - name: Upgrade npm
+        run: npm install -g npm@latest
 
       - name: Check if version already on npm
         id: check
@@ -32,8 +35,4 @@ jobs:
 
       - name: Publish
         if: steps.check.outputs.exists == 'false'
-        run: |
-          unset NODE_AUTH_TOKEN
-          npm config delete //registry.npmjs.org/:_authToken || true
-          npm config delete always-auth || true
-          npm publish --provenance --access public
+        run: npm publish --provenance --access public

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,8 +1,7 @@
 name: Publish to npm
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://registry.npmjs.org/
 
       - name: Check if version already on npm
         id: check

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: https://registry.npmjs.org/
 
       - name: Check if version already on npm
         id: check

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,35 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Check if version already on npm
+        id: check
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view strapi-v5-plugin-populate-deep@$VERSION version 2>/dev/null; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Publish
+        if: steps.check.outputs.exists == 'false'
+        run: npm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,16 +2,6 @@ name: Create Release
 
 on:
   workflow_dispatch:
-    inputs:
-      bump:
-        description: 'Version bump type'
-        required: true
-        default: patch
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
 
 permissions:
   contents: write
@@ -31,26 +21,32 @@ jobs:
         with:
           node-version: 20
 
-      - name: Bump version
-        id: version
-        run: |
-          npm version ${{ inputs.bump }} --no-git-tag-version
-          VERSION=$(node -p "require('./package.json').version")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+      - name: Bump version and create tag
+        id: tag
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: patch
+          release_branches: main
 
-      - name: Commit and tag
+      - name: Update package.json version
         run: |
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+            pkg.version = '${{ steps.tag.outputs.new_version }}';
+            fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json
-          git commit -m "chore: release v${{ steps.version.outputs.version }}"
-          git tag v${{ steps.version.outputs.version }}
-          git push --follow-tags
+          git commit -m "chore: release v${{ steps.tag.outputs.new_version }}"
+          git push
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create v${{ steps.version.outputs.version }} \
+          gh release create ${{ steps.tag.outputs.new_tag }} \
             --generate-notes \
-            --title "v${{ steps.version.outputs.version }}"
+            --title "${{ steps.tag.outputs.new_tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type'
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Bump version
+        id: version
+        run: |
+          npm version ${{ inputs.bump }} --no-git-tag-version
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Commit and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json
+          git commit -m "chore: release v${{ steps.version.outputs.version }}"
+          git tag v${{ steps.version.outputs.version }}
+          git push --follow-tags
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create v${{ steps.version.outputs.version }} \
+            --generate-notes \
+            --title "v${{ steps.version.outputs.version }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ With Strapi v5, a new [API structure validation feature](https://github.com/stra
 
 `yarn add strapi-v5-plugin-populate-deep`
 
+Also, the npm link is [here](https://www.npmjs.com/package/strapi-v5-plugin-populate-deep).
+
 # Usages
 
 The plugin allows you to deeply populate data in your Strapi queries with a new parameter pLevel. This parameter specifies the depth of population for your API responses.
@@ -56,5 +58,7 @@ This configuration will set the default depth to 3 levels across all API request
 This plugin is a fork of the original work by [Barelydead](https://github.com/Barelydead/) and can be found in the original [repository](https://github.com/Barelydead/strapi-plugin-populate-deep).
 
 The original idea for getting the populate structure was created by [tomnovotny7](https://github.com/tomnovotny7) and can be found in [this](https://github.com/strapi/strapi/issues/11836) github thread
+
+Thank you to [tooonuch](https://github.com/tooonuch) for fixing the dynamic zone population issue. He resolved a problem where components with the same attribute name were not populated correctly by using the `on` property. This improvement helps ensure proper population for all components.
 
 We appreciate and acknowledge all contributions made by the open-source community to the original project.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To customize the default depth, add or modify the config/plugins.js file as show
 
 ```
 module.exports = ({ env }) => ({
-  'strapi-plugin-populate-deep': {
+  'strapi-v5-plugin-populate-deep': {
     config: {
       defaultDepth: 3, // Default is 5
     }

--- a/README.md
+++ b/README.md
@@ -1,41 +1,42 @@
-# Strapi plugin populate-deep
-This plugin allows for easier population of deep content structures using the rest API.
+# Strapi v5 Plugin: populate-deep
+
+This plugin is a fork of the original [strapi-plugin-populate-deep](https://github.com/Barelydead/strapi-plugin-populate-deep), which does not support Strapi v5 at the time of this publication.
+
+## Why this Fork?
+
+With Strapi v5, a new [API structure validation feature](https://github.com/strapi/strapi/pull/21034) was introduced, which makes the populate parameter incompatible with how the original plugin works. This plugin addresses that by introducing a new parameter pLevel to avoid validation issues.
 
 # Installation
 
-`npm install strapi-plugin-populate-deep`
+`npm install strapi-v5-plugin-populate-deep`
 
-`yarn add strapi-plugin-populate-deep`
-
+`yarn add strapi-v5-plugin-populate-deep`
 
 # Usages
 
+The plugin allows you to deeply populate data in your Strapi queries with a new parameter pLevel. This parameter specifies the depth of population for your API responses.
+
 ## Examples
 
-Populate a request with the default max depth.
+1. Populate a request with the default max depth.
+   `/api/articles?pLevel`
 
-`/api/articles?populate=deep`
-
-Populate a request with the a custom depth
-
-`/api/articles?populate=deep,10`
-
-Populate a request with the a custom depth
-
-`/api/articles/1?populate=deep,10`
+2. Populate a request with the a custom depth
+   `/api/articles?pLevel=10`
 
 ## Good to know
 
-The default max depth is 5 levels deep.
-
-The populate deep option is available for all collections and single types using the findOne and findMany methods.
+- The default maximum depth is 5 levels deep.
+- The pLevel parameter works for all collections and single types when using findOne and findMany methods.
+- Increasing the depth level may result in longer API response times.
 
 # Configuration
 
-The default depth can be customized via the plugin config. To do so create or edit you plugins.js file.
+You can configure the default depth globally through the plugin configuration.
 
 ## Example configuration
 
+To customize the default depth, add or modify the config/plugins.js file as shown below:
 `config/plugins.js`
 
 ```
@@ -48,5 +49,12 @@ module.exports = ({ env }) => ({
 });
 ```
 
+This configuration will set the default depth to 3 levels across all API requests unless specified otherwise in the request itself.
+
 # Contributions
+
+This plugin is a fork of the original work by [Barelydead](https://github.com/Barelydead/) and can be found in the original [repository](https://github.com/Barelydead/strapi-plugin-populate-deep).
+
 The original idea for getting the populate structure was created by [tomnovotny7](https://github.com/tomnovotny7) and can be found in [this](https://github.com/strapi/strapi/issues/11836) github thread
+
+We appreciate and acknowledge all contributions made by the open-source community to the original project.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ module.exports = ({ env }) => ({
 
 This configuration will set the default depth to 3 levels across all API requests unless specified otherwise in the request itself.
 
+# Contributors
+
+<a href="https://github.com/NEDDL/strapi-v5-plugin-populate-deep/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=NEDDL/strapi-v5-plugin-populate-deep" />
+</a>
+
 # Contributions
 
 This plugin is a fork of the original work by [Barelydead](https://github.com/Barelydead/) and can be found in the original [repository](https://github.com/Barelydead/strapi-plugin-populate-deep).

--- a/README.md
+++ b/README.md
@@ -1,70 +1,92 @@
-# Strapi v5 Plugin: populate-deep
+# strapi-v5-plugin-populate-deep
 
-This plugin is a fork of the original [strapi-plugin-populate-deep](https://github.com/Barelydead/strapi-plugin-populate-deep), which does not support Strapi v5 at the time of this publication.
+A Strapi v5 plugin that enables deep population of nested content structures via a simple query parameter.
 
-## Why this Fork?
+[![npm version](https://img.shields.io/npm/v/strapi-v5-plugin-populate-deep?label=version&color=blue)](https://www.npmjs.com/package/strapi-v5-plugin-populate-deep)
+[![npm downloads](https://img.shields.io/npm/dm/strapi-v5-plugin-populate-deep?color=brightgreen)](https://www.npmjs.com/package/strapi-v5-plugin-populate-deep)
+[![npm total downloads](https://img.shields.io/npm/dt/strapi-v5-plugin-populate-deep)](https://www.npmjs.com/package/strapi-v5-plugin-populate-deep)
+[![license](https://img.shields.io/npm/l/strapi-v5-plugin-populate-deep)](./LICENSE)
+[![node](https://img.shields.io/node/v/strapi-v5-plugin-populate-deep)](https://www.npmjs.com/package/strapi-v5-plugin-populate-deep)
+[![bundle size](https://img.shields.io/bundlephobia/min/strapi-v5-plugin-populate-deep)](https://bundlephobia.com/package/strapi-v5-plugin-populate-deep)
+[![GitHub stars](https://img.shields.io/github/stars/NEDDL/strapi-v5-plugin-populate-deep?style=social)](https://github.com/NEDDL/strapi-v5-plugin-populate-deep/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/NEDDL/strapi-v5-plugin-populate-deep?style=social)](https://github.com/NEDDL/strapi-v5-plugin-populate-deep/network/members)
+[![GitHub issues](https://img.shields.io/github/issues/NEDDL/strapi-v5-plugin-populate-deep)](https://github.com/NEDDL/strapi-v5-plugin-populate-deep/issues)
+[![GitHub last commit](https://img.shields.io/github/last-commit/NEDDL/strapi-v5-plugin-populate-deep)](https://github.com/NEDDL/strapi-v5-plugin-populate-deep/commits/main)
+[![GitHub contributors](https://img.shields.io/github/contributors/NEDDL/strapi-v5-plugin-populate-deep)](https://github.com/NEDDL/strapi-v5-plugin-populate-deep/graphs/contributors)
+[![Strapi v5](https://img.shields.io/badge/Strapi-v5-8C4BFF?logo=strapi)](https://strapi.io)
 
-With Strapi v5, a new [API structure validation feature](https://github.com/strapi/strapi/pull/21034) was introduced, which makes the populate parameter incompatible with how the original plugin works. This plugin addresses that by introducing a new parameter pLevel to avoid validation issues.
+## Installation
 
-# Installation
+```bash
+npm install strapi-v5-plugin-populate-deep
+# or
+yarn add strapi-v5-plugin-populate-deep
+```
 
-`npm install strapi-v5-plugin-populate-deep`
+## Usage
 
-`yarn add strapi-v5-plugin-populate-deep`
+Add `pLevel` to any API request to deeply populate the response.
 
-Also, the npm link is [here](https://www.npmjs.com/package/strapi-v5-plugin-populate-deep).
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `pLevel` | `number` (optional) | Depth of population. Omit the value to use the default depth. |
+| `pIgnore` | `string` or `string[]` (optional) | Fields or collection names to exclude from population. Accepts a comma-separated string or array. |
 
-# Usages
-
-The plugin allows you to deeply populate data in your Strapi queries with a new parameter pLevel. This parameter specifies the depth of population for your API responses.
-
-## Examples
-
-1. Populate a request with the default max depth.
-   `/api/articles?pLevel`
-
-2. Populate a request with the a custom depth
-   `/api/articles?pLevel=10`
-
-## Good to know
-
-- The default maximum depth is 5 levels deep.
-- The pLevel parameter works for all collections and single types when using findOne and findMany methods.
-- Increasing the depth level may result in longer API response times.
-
-# Configuration
-
-You can configure the default depth globally through the plugin configuration.
-
-## Example configuration
-
-To customize the default depth, add or modify the config/plugins.js file as shown below:
-`config/plugins.js`
+### Examples
 
 ```
+# Use default depth (5)
+GET /api/articles?pLevel
+
+# Use custom depth
+GET /api/articles?pLevel=10
+
+# Ignore specific fields (comma-separated string)
+GET /api/articles?pLevel=5&pIgnore=author,tags
+
+# Ignore specific fields (array syntax)
+GET /api/articles?pLevel=5&pIgnore[0]=author&pIgnore[1]=tags
+```
+
+## Configuration
+
+Customize the default depth globally via `config/plugins.js` (or `.ts`):
+
+```js
+// config/plugins.js
 module.exports = ({ env }) => ({
   'strapi-v5-plugin-populate-deep': {
     config: {
-      defaultDepth: 3, // Default is 5
-    }
+      defaultDepth: 3, // default: 5
+    },
   },
 });
 ```
 
-This configuration will set the default depth to 3 levels across all API requests unless specified otherwise in the request itself.
+## Good to Know
 
-# Contributors
+- Default depth is **5** unless configured otherwise.
+- Works for all collections and single types (`findOne` and `findMany`).
+- `pIgnore` prevents circular population and can significantly reduce response size and query time.
+- Increasing depth may result in longer response times — use `pIgnore` to offset this.
+- `plugin::upload.file` related field is always excluded to avoid bloated responses.
+- `admin::user` (creator fields) can be excluded via `skipCreatorFields` config:
+
+```js
+module.exports = ({ env }) => ({
+  'strapi-v5-plugin-populate-deep': {
+    config: {
+      defaultDepth: 5,
+      skipCreatorFields: true,
+    },
+  },
+});
+```
+
+## Contributors
 
 <a href="https://github.com/NEDDL/strapi-v5-plugin-populate-deep/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=NEDDL/strapi-v5-plugin-populate-deep" />
 </a>
 
-# Contributions
-
-This plugin is a fork of the original work by [Barelydead](https://github.com/Barelydead/) and can be found in the original [repository](https://github.com/Barelydead/strapi-plugin-populate-deep).
-
-The original idea for getting the populate structure was created by [tomnovotny7](https://github.com/tomnovotny7) and can be found in [this](https://github.com/strapi/strapi/issues/11836) github thread
-
-Thank you to [tooonuch](https://github.com/tooonuch) for fixing the dynamic zone population issue. He resolved a problem where components with the same attribute name were not populated correctly by using the `on` property. This improvement helps ensure proper population for all components.
-
-We appreciate and acknowledge all contributions made by the open-source community to the original project.
+Based on the original work by [Barelydead](https://github.com/Barelydead/strapi-plugin-populate-deep). Original populate concept by [tomnovotny7](https://github.com/tomnovotny7) ([thread](https://github.com/strapi/strapi/issues/11836)). Dynamic zone fix by [tooonuch](https://github.com/tooonuch).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Strapi v5 plugin that enables deep population of nested content structures via
 [![npm total downloads](https://img.shields.io/npm/dt/strapi-v5-plugin-populate-deep)](https://www.npmjs.com/package/strapi-v5-plugin-populate-deep)
 [![license](https://img.shields.io/npm/l/strapi-v5-plugin-populate-deep)](./LICENSE)
 [![node](https://img.shields.io/node/v/strapi-v5-plugin-populate-deep)](https://www.npmjs.com/package/strapi-v5-plugin-populate-deep)
-[![bundle size](https://img.shields.io/bundlephobia/min/strapi-v5-plugin-populate-deep)](https://bundlephobia.com/package/strapi-v5-plugin-populate-deep)
+[![install size](https://packagephobia.com/badge?p=strapi-v5-plugin-populate-deep)](https://packagephobia.com/result?p=strapi-v5-plugin-populate-deep)
 [![GitHub stars](https://img.shields.io/github/stars/NEDDL/strapi-v5-plugin-populate-deep?style=social)](https://github.com/NEDDL/strapi-v5-plugin-populate-deep/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/NEDDL/strapi-v5-plugin-populate-deep?style=social)](https://github.com/NEDDL/strapi-v5-plugin-populate-deep/network/members)
 [![GitHub issues](https://img.shields.io/github/issues/NEDDL/strapi-v5-plugin-populate-deep)](https://github.com/NEDDL/strapi-v5-plugin-populate-deep/issues)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "strapi-plugin-populate-deep",
-  "version": "3.0.1",
+  "version": "4.0.5",
   "lockfileVersion": 1
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,17 @@
 {
   "name": "strapi-v5-plugin-populate-deep",
-  "version": "4.2.2",
+  "version": "4.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "strapi-v5-plugin-populate-deep",
-      "version": "4.2.2",
+      "version": "4.3.1",
       "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.23"
-      },
       "engines": {
         "node": ">=18.0.0 <=24.x.x",
         "npm": ">=6.0.0"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,26 @@
 {
-  "name": "strapi-plugin-populate-deep",
-  "version": "4.0.5",
-  "lockfileVersion": 1
+  "name": "strapi-v5-plugin-populate-deep",
+  "version": "4.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "strapi-v5-plugin-populate-deep",
+      "version": "4.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.23"
+      },
+      "engines": {
+        "node": ">=18.0.0 <=24.x.x",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "strapi-v5-plugin-populate-deep",
-  "version": "4.2.0",
+  "version": "4.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "strapi-v5-plugin-populate-deep",
-      "version": "4.2.0",
+      "version": "4.2.2",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.23"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-v5-plugin-populate-deep",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Strapi v5 plugin that populates nested content.",
   "strapi": {
     "name": "strapi-v5-plugin-populate-deep",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-v5-plugin-populate-deep",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Strapi v5 plugin that populates nested content.",
   "strapi": {
     "name": "strapi-v5-plugin-populate-deep",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/NEDDL/strapi-v5-plugin-populate-deep"
   },
   "engines": {
-    "node": ">=14.19.1 <=20.x.x",
+    "node": ">=18.0.0 <=22.x.x",
     "npm": ">=6.0.0"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "strapi-v5-plugin-populate-deep",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Strapi v5 plugin that populates nested content.",
   "strapi": {
-    "name": "Populate Deep for Strapi v5",
+    "name": "strapi-v5-plugin-populate-deep",
     "description": "API helper to populate deep content structures for Strapi v5.",
     "kind": "plugin"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-v5-plugin-populate-deep",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Strapi v5 plugin that populates nested content.",
   "strapi": {
     "name": "strapi-v5-plugin-populate-deep",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "strapi-v5-plugin-populate-deep",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Strapi v5 plugin that populates nested content.",
   "strapi": {
-    "name": "strapi-v5-plugin-populate-deep",
+    "name": "Populate Deep for Strapi v5",
     "description": "API helper to populate deep content structures for Strapi v5.",
     "kind": "plugin"
   },

--- a/package.json
+++ b/package.json
@@ -1,24 +1,28 @@
 {
-  "name": "strapi-plugin-populate-deep",
-  "version": "3.0.1",
-  "description": "Strapi plugin that populates nested content.",
+  "name": "strapi-v5-plugin-populate-deep",
+  "version": "4.0.0",
+  "description": "Strapi v5 plugin that populates nested content.",
   "strapi": {
-    "name": "strapi-plugin-populate-deep",
-    "description": "Api helper to populate deep content structures.",
+    "name": "strapi-v5-plugin-populate-deep",
+    "description": "API helper to populate deep content structures for Strapi v5.",
     "kind": "plugin"
   },
   "dependencies": {},
   "author": {
-    "name": "Christofer Jungberg"
+    "name": "Mustafa ONAL"
   },
+  "contributors": [
+    "Christofer Jungberg",
+    "Mustafa ONAL"
+  ],
   "maintainers": [
     {
-      "name": "Christofer Jungberg"
+      "name": "Mustafa ONAL"
     }
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Barelydead/strapi-plugin-deep-populate"
+    "url": "https://github.com/NEDDL/strapi-v5-plugin-populate-deep"
   },
   "engines": {
     "node": ">=14.19.1 <=20.x.x",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/NEDDL/strapi-v5-plugin-populate-deep"
   },
   "engines": {
-    "node": ">=18.0.0 <=22.x.x",
+    "node": ">=18.0.0 <=24.x.x",
     "npm": ">=6.0.0"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-v5-plugin-populate-deep",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "Strapi v5 plugin that populates nested content.",
   "strapi": {
     "name": "strapi-v5-plugin-populate-deep",
@@ -13,7 +13,8 @@
   },
   "contributors": [
     "Christofer Jungberg",
-    "Mustafa ONAL"
+    "Mustafa ONAL",
+    "chohner"
   ],
   "maintainers": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-v5-plugin-populate-deep",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Strapi v5 plugin that populates nested content.",
   "strapi": {
     "name": "strapi-v5-plugin-populate-deep",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-v5-plugin-populate-deep",
-  "version": "4.0.6",
+  "version": "4.1.0",
   "description": "Strapi v5 plugin that populates nested content.",
   "strapi": {
     "name": "strapi-v5-plugin-populate-deep",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-v5-plugin-populate-deep",
-  "version": "4.2.2",
+  "version": "4.3.0",
   "description": "Strapi v5 plugin that populates nested content.",
   "strapi": {
     "name": "strapi-v5-plugin-populate-deep",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
     "description": "API helper to populate deep content structures for Strapi v5.",
     "kind": "plugin"
   },
-  "dependencies": {
-    "lodash": "^4.17.23"
-  },
   "author": {
     "name": "Mustafa ONAL"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-v5-plugin-populate-deep",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Strapi v5 plugin that populates nested content.",
   "strapi": {
     "name": "strapi-v5-plugin-populate-deep",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-v5-plugin-populate-deep",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Strapi v5 plugin that populates nested content.",
   "strapi": {
     "name": "strapi-v5-plugin-populate-deep",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-v5-plugin-populate-deep",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Strapi v5 plugin that populates nested content.",
   "strapi": {
     "name": "strapi-v5-plugin-populate-deep",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "description": "API helper to populate deep content structures for Strapi v5.",
     "kind": "plugin"
   },
-  "dependencies": {},
+  "dependencies": {
+    "lodash": "^4.17.23"
+  },
   "author": {
     "name": "Mustafa ONAL"
   },

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -2,25 +2,22 @@
 const { getFullPopulateObject } = require("./helpers");
 
 module.exports = ({ strapi }) => {
+  // Subscribe to the lifecycles that we are intrested in.
   strapi.db.lifecycles.subscribe((event) => {
     if (event.action === "beforeFindMany" || event.action === "beforeFindOne") {
-      const deepPopulate = event.params?.deeppopulate;
+      const level = event.params?.pLevel;
+      console.log("level", level);
+
       const defaultDepth =
-        strapi.plugin("custom-deep-populate")?.config("defaultDepth") || 5;
+        strapi.plugin("strapi-plugin-populate-deep")?.config("defaultDepth") ||
+        5;
 
-      console.log("Custom Plugin: Deep populate param:", deepPopulate); // Debugging
-
-      if (deepPopulate && deepPopulate[0] === "deep") {
-        const depth = deepPopulate[1] ?? defaultDepth;
-        console.log(
-          `Custom Plugin: Applying deep population with depth: ${depth}`
-        ); // Debugging
+      if (level !== undefined) {
+        const depth = level ?? defaultDepth;
+        console.log("depth", depth);
         const modelObject = getFullPopulateObject(event.model.uid, depth, []);
+        console.log("modelObject", modelObject);
         event.params.populate = modelObject.populate;
-        console.log(
-          "Custom Plugin: Final populate object:",
-          event.params.populate
-        ); // Debugging
       }
     }
   });

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -6,7 +6,6 @@ module.exports = ({ strapi }) => {
   strapi.db.lifecycles.subscribe((event) => {
     if (event.action === "beforeFindMany" || event.action === "beforeFindOne") {
       const level = event.params?.pLevel;
-      console.log("level", level);
 
       const defaultDepth =
         strapi
@@ -15,9 +14,7 @@ module.exports = ({ strapi }) => {
 
       if (level !== undefined) {
         const depth = level ?? defaultDepth;
-        console.log("depth", depth);
         const modelObject = getFullPopulateObject(event.model.uid, depth, []);
-        console.log("modelObject", modelObject);
         event.params.populate = modelObject.populate;
       }
     }

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -1,17 +1,18 @@
-'use strict';
-const { getFullPopulateObject } = require('./helpers')
+"use strict";
+const { getFullPopulateObject } = require("./helpers");
 
 module.exports = ({ strapi }) => {
-  // Subscribe to the lifecycles that we are intrested in.
   strapi.db.lifecycles.subscribe((event) => {
-    if (event.action === 'beforeFindMany' || event.action === 'beforeFindOne') {
-      const populate = event.params?.populate;
-      const defaultDepth = strapi.plugin('strapi-plugin-populate-deep')?.config('defaultDepth') || 5
+    if (event.action === "beforeFindMany" || event.action === "beforeFindOne") {
+      const deepPopulate = event.params?.deeppopulate;
+      const defaultDepth =
+        strapi.plugin("strapi-plugin-populate-deep")?.config("defaultDepth") ||
+        5;
 
-      if (populate && populate[0] === 'deep') {
-        const depth = populate[1] ?? defaultDepth
+      if (deepPopulate && deepPopulate[0] === "deep") {
+        const depth = deepPopulate[1] ?? defaultDepth;
         const modelObject = getFullPopulateObject(event.model.uid, depth, []);
-        event.params.populate = modelObject.populate
+        event.params.populate = modelObject.populate;
       }
     }
   });

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -9,8 +9,9 @@ module.exports = ({ strapi }) => {
       console.log("level", level);
 
       const defaultDepth =
-        strapi.plugin("strapi-plugin-populate-deep")?.config("defaultDepth") ||
-        5;
+        strapi
+          .plugin("strapi-v5-plugin-populate-deep")
+          ?.config("defaultDepth") || 5;
 
       if (level !== undefined) {
         const depth = level ?? defaultDepth;

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -6,13 +6,21 @@ module.exports = ({ strapi }) => {
     if (event.action === "beforeFindMany" || event.action === "beforeFindOne") {
       const deepPopulate = event.params?.deeppopulate;
       const defaultDepth =
-        strapi.plugin("strapi-plugin-populate-deep")?.config("defaultDepth") ||
-        5;
+        strapi.plugin("custom-deep-populate")?.config("defaultDepth") || 5;
+
+      console.log("Custom Plugin: Deep populate param:", deepPopulate); // Debugging
 
       if (deepPopulate && deepPopulate[0] === "deep") {
         const depth = deepPopulate[1] ?? defaultDepth;
+        console.log(
+          `Custom Plugin: Applying deep population with depth: ${depth}`
+        ); // Debugging
         const modelObject = getFullPopulateObject(event.model.uid, depth, []);
         event.params.populate = modelObject.populate;
+        console.log(
+          "Custom Plugin: Final populate object:",
+          event.params.populate
+        ); // Debugging
       }
     }
   });

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -22,6 +22,9 @@ module.exports = ({ strapi }) => {
     const ignore = typeof pIgnore === 'string' ? pIgnore.split(',').map(s => s.trim()) : Array.isArray(pIgnore) ? pIgnore : [pIgnore];
 
     const depth = pLevel ? parseInt(pLevel, 10) : defaultDepth;
-    params.populate = getFullPopulateObject(model.uid, depth, ignore).populate;
+    const populateObj = getFullPopulateObject(model.uid, depth, ignore);
+    if (populateObj && populateObj !== true) {
+      params.populate = populateObj.populate;
+    }
   });
 };

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -2,21 +2,23 @@
 const { getFullPopulateObject } = require("./helpers");
 
 module.exports = ({ strapi }) => {
-  // Subscribe to the lifecycles that we are intrested in.
+  const defaultDepth =
+    strapi.plugin("strapi-v5-plugin-populate-deep")?.config("defaultDepth") ||
+    5;
+
   strapi.db.lifecycles.subscribe((event) => {
-    if (event.action === "beforeFindMany" || event.action === "beforeFindOne") {
-      const level = event.params?.pLevel;
+    const { action, model, params } = event;
 
-      const defaultDepth =
-        strapi
-          .plugin("strapi-v5-plugin-populate-deep")
-          ?.config("defaultDepth") || 5;
+    if (!["beforeFindMany", "beforeFindOne"].includes(action)) return;
+    if (!model.uid.startsWith("api::")) return;
 
-      if (level !== undefined) {
-        const depth = level ?? defaultDepth;
-        const modelObject = getFullPopulateObject(event.model.uid, depth, []);
-        event.params.populate = modelObject.populate;
-      }
-    }
+    const ctx = strapi.requestContext.get();
+    if (!ctx?.request?.url?.startsWith("/api/")) return;
+
+    const pLevel = params?.pLevel ?? ctx.query?.pLevel;
+    if (pLevel === undefined) return;
+
+    const depth = pLevel ? parseInt(pLevel, 10) : defaultDepth;
+    params.populate = getFullPopulateObject(model.uid, depth, []).populate;
   });
 };

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -19,7 +19,7 @@ module.exports = ({ strapi }) => {
     if (pLevel === undefined) return;
 
     const pIgnore = params?.pIgnore ?? ctx.query?.pIgnore ?? [];
-    const ignore = Array.isArray(pIgnore) ? pIgnore : [pIgnore];
+    const ignore = typeof pIgnore === 'string' ? pIgnore.split(',').map(s => s.trim()) : Array.isArray(pIgnore) ? pIgnore : [pIgnore];
 
     const depth = pLevel ? parseInt(pLevel, 10) : defaultDepth;
     params.populate = getFullPopulateObject(model.uid, depth, ignore).populate;

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -18,7 +18,10 @@ module.exports = ({ strapi }) => {
     const pLevel = params?.pLevel ?? ctx.query?.pLevel;
     if (pLevel === undefined) return;
 
+    const pIgnore = params?.pIgnore ?? ctx.query?.pIgnore ?? [];
+    const ignore = Array.isArray(pIgnore) ? pIgnore : [pIgnore];
+
     const depth = pLevel ? parseInt(pLevel, 10) : defaultDepth;
-    params.populate = getFullPopulateObject(model.uid, depth, []).populate;
+    params.populate = getFullPopulateObject(model.uid, depth, ignore).populate;
   });
 };

--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -39,6 +39,7 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
         }, {});
         populate[key] = isEmpty(dynamicPopulate) ? true : { on: dynamicPopulate };
       } else if (value.type === "relation") {
+        if (ignore?.includes(strapi.getModel(value.target).collectionName)) continue;
         const relationPopulate = getFullPopulateObject(
             value.target,
             key === "localizations" && maxDepth > 2 ? 1 : maxDepth - 1,

--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -11,7 +11,7 @@ const getModelPopulationAttributes = (model) => {
 
 const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
   const skipCreatorFields = strapi
-      .plugin("strapi-plugin-populate-deep")
+      .plugin("strapi-v5-plugin-populate-deep")
       ?.config("skipCreatorFields");
 
   if (maxDepth <= 1) {

--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -10,7 +10,9 @@ const getModelPopulationAttributes = (model) => {
 };
 
 const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
-  const skipCreatorFields = strapi.plugin('strapi-plugin-populate-deep')?.config('skipCreatorFields');
+  const skipCreatorFields = strapi
+    .plugin("strapi-plugin-populate-deep")
+    ?.config("skipCreatorFields");
 
   if (maxDepth <= 1) {
     return true;
@@ -21,11 +23,12 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
 
   const populate = {};
   const model = strapi.getModel(modelUid);
-  if (ignore && !ignore.includes(model.collectionName)) ignore.push(model.collectionName)
+  if (ignore && !ignore.includes(model.collectionName))
+    ignore.push(model.collectionName);
   for (const [key, value] of Object.entries(
     getModelPopulationAttributes(model)
   )) {
-    if (ignore?.includes(key)) continue
+    if (ignore?.includes(key)) continue;
     if (value) {
       if (value.type === "component") {
         populate[key] = getFullPopulateObject(value.component, maxDepth - 1);
@@ -38,7 +41,7 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
       } else if (value.type === "relation") {
         const relationPopulate = getFullPopulateObject(
           value.target,
-          (key === 'localizations') && maxDepth > 2 ? 1 : maxDepth - 1,
+          key === "localizations" && maxDepth > 2 ? 1 : maxDepth - 1,
           ignore
         );
         if (relationPopulate) {
@@ -53,5 +56,5 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
 };
 
 module.exports = {
-  getFullPopulateObject
-}
+  getFullPopulateObject,
+};

--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -11,8 +11,8 @@ const getModelPopulationAttributes = (model) => {
 
 const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
   const skipCreatorFields = strapi
-    .plugin("strapi-plugin-populate-deep")
-    ?.config("skipCreatorFields");
+      .plugin("strapi-plugin-populate-deep")
+      ?.config("skipCreatorFields");
 
   if (maxDepth <= 1) {
     return true;
@@ -26,7 +26,7 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
   if (ignore && !ignore.includes(model.collectionName))
     ignore.push(model.collectionName);
   for (const [key, value] of Object.entries(
-    getModelPopulationAttributes(model)
+      getModelPopulationAttributes(model)
   )) {
     if (ignore?.includes(key)) continue;
     if (value) {
@@ -35,14 +35,14 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
       } else if (value.type === "dynamiczone") {
         const dynamicPopulate = value.components.reduce((prev, cur) => {
           const curPopulate = getFullPopulateObject(cur, maxDepth - 1);
-          return curPopulate === true ? prev : merge(prev, curPopulate);
+          return merge(prev, {[cur]: curPopulate});
         }, {});
-        populate[key] = isEmpty(dynamicPopulate) ? true : dynamicPopulate;
+        populate[key] = isEmpty(dynamicPopulate) ? true : { on: dynamicPopulate };
       } else if (value.type === "relation") {
         const relationPopulate = getFullPopulateObject(
-          value.target,
-          key === "localizations" && maxDepth > 2 ? 1 : maxDepth - 1,
-          ignore
+            value.target,
+            key === "localizations" && maxDepth > 2 ? 1 : maxDepth - 1,
+            ignore
         );
         if (relationPopulate) {
           populate[key] = relationPopulate;

--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -58,7 +58,7 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
       } else if (value.type === "dynamiczone") {
         const dynamicPopulate = value.components.reduce((prev, cur) => {
           const curPopulate = getFullPopulateObject(cur, maxDepth - 1, ignore);
-          return curPopulate === true ? prev : deepAssign(prev, { [cur]: curPopulate });
+          return curPopulate === undefined ? prev : deepAssign(prev, { [cur]: curPopulate });
         }, {});
         populate[key] = isEmpty(dynamicPopulate) ? true : { on: dynamicPopulate };
       } else if (value.type === "relation") {

--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -1,4 +1,28 @@
-const { isEmpty, merge } = require("lodash/fp");
+const { isEmpty } = require("lodash/fp");
+
+const deepAssign = (target, source) => {
+  for (const key in source) {
+    if (Object.prototype.hasOwnProperty.call(source, key)) {
+      if (typeof source[key] === "object" && source[key] !== null) {
+        if (
+          !target[key] ||
+          typeof target[key] !== "object" ||
+          target[key] === null
+        ) {
+          target[key] = source[key];
+        }
+        deepAssign(target[key], source[key]);
+      } else if (
+        !target[key] ||
+        typeof target[key] !== "object" ||
+        target[key] === null
+      ) {
+        target[key] = source[key];
+      }
+    }
+  }
+  return target;
+};
 
 const getModelPopulationAttributes = (model) => {
   if (model.uid === "plugin::upload.file") {
@@ -11,8 +35,8 @@ const getModelPopulationAttributes = (model) => {
 
 const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
   const skipCreatorFields = strapi
-      .plugin("strapi-v5-plugin-populate-deep")
-      ?.config("skipCreatorFields");
+    .plugin("strapi-v5-plugin-populate-deep")
+    ?.config("skipCreatorFields");
 
   if (maxDepth <= 1) {
     return true;
@@ -26,24 +50,24 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
   if (ignore && !ignore.includes(model.collectionName))
     ignore.push(model.collectionName);
   for (const [key, value] of Object.entries(
-      getModelPopulationAttributes(model)
+    getModelPopulationAttributes(model)
   )) {
-    if (ignore?.includes(key)) continue;
+    if (ignore?.includes(key) || value.private === true) continue;
     if (value) {
       if (value.type === "component") {
-        populate[key] = getFullPopulateObject(value.component, maxDepth - 1);
+        populate[key] = getFullPopulateObject(value.component, maxDepth - 1, ignore);
       } else if (value.type === "dynamiczone") {
         const dynamicPopulate = value.components.reduce((prev, cur) => {
-          const curPopulate = getFullPopulateObject(cur, maxDepth - 1);
-          return merge(prev, {[cur]: curPopulate});
+          const curPopulate = getFullPopulateObject(cur, maxDepth - 1, ignore);
+          return curPopulate === true ? prev : deepAssign(prev, { [cur]: curPopulate });
         }, {});
         populate[key] = isEmpty(dynamicPopulate) ? true : { on: dynamicPopulate };
       } else if (value.type === "relation") {
         if (ignore?.includes(strapi.getModel(value.target).collectionName)) continue;
         const relationPopulate = getFullPopulateObject(
-            value.target,
-            key === "localizations" && maxDepth > 2 ? 1 : maxDepth - 1,
-            ignore
+          value.target,
+          key === "localizations" && maxDepth > 2 ? 1 : maxDepth - 1,
+          ignore
         );
         if (relationPopulate) {
           populate[key] = relationPopulate;

--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -1,4 +1,4 @@
-const { isEmpty } = require("lodash/fp");
+const isEmpty = (obj) => Object.keys(obj).length === 0;
 
 const deepAssign = (target, source) => {
   for (const key in source) {

--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -62,14 +62,18 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
         }, {});
         populate[key] = isEmpty(dynamicPopulate) ? true : { on: dynamicPopulate };
       } else if (value.type === "relation") {
-        if (ignore?.includes(strapi.getModel(value.target).collectionName)) continue;
-        const relationPopulate = getFullPopulateObject(
-          value.target,
-          key === "localizations" && maxDepth > 2 ? 1 : maxDepth - 1,
-          [...ignore]
-        );
-        if (relationPopulate) {
-          populate[key] = relationPopulate;
+        if (key === "localizations") {
+          populate[key] = true;
+        } else {
+          if (ignore?.includes(strapi.getModel(value.target).collectionName)) continue;
+          const relationPopulate = getFullPopulateObject(
+            value.target,
+            maxDepth - 1,
+            [...ignore]
+          );
+          if (relationPopulate) {
+            populate[key] = relationPopulate;
+          }
         }
       } else if (value.type === "media") {
         populate[key] = true;

--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -54,10 +54,10 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
     if (ignore?.includes(key) || value.private === true) continue;
     if (value) {
       if (value.type === "component") {
-        populate[key] = getFullPopulateObject(value.component, maxDepth - 1, ignore);
+        populate[key] = getFullPopulateObject(value.component, maxDepth - 1, [...ignore]);
       } else if (value.type === "dynamiczone") {
         const dynamicPopulate = value.components.reduce((prev, cur) => {
-          const curPopulate = getFullPopulateObject(cur, maxDepth - 1, ignore);
+          const curPopulate = getFullPopulateObject(cur, maxDepth - 1, [...ignore]);
           return curPopulate === undefined ? prev : deepAssign(prev, { [cur]: curPopulate });
         }, {});
         populate[key] = isEmpty(dynamicPopulate) ? true : { on: dynamicPopulate };
@@ -66,7 +66,7 @@ const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
         const relationPopulate = getFullPopulateObject(
           value.target,
           key === "localizations" && maxDepth > 2 ? 1 : maxDepth - 1,
-          ignore
+          [...ignore]
         );
         if (relationPopulate) {
           populate[key] = relationPopulate;

--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -34,14 +34,13 @@ const getModelPopulationAttributes = (model) => {
 };
 
 const getFullPopulateObject = (modelUid, maxDepth = 20, ignore) => {
-  const skipCreatorFields = strapi
-    .plugin("strapi-v5-plugin-populate-deep")
-    ?.config("skipCreatorFields");
-
   if (maxDepth <= 1) {
     return true;
   }
-  if (modelUid === "admin::user" && skipCreatorFields) {
+
+  if (modelUid === "admin::user" && strapi
+    .plugin("strapi-v5-plugin-populate-deep")
+    ?.config("skipCreatorFields")) {
     return undefined;
   }
 

--- a/server/index.js
+++ b/server/index.js
@@ -5,5 +5,10 @@ const config = require('./config')
 
 module.exports = {
   bootstrap,
-  config
+  config,
+  register: ({ strapi }) => {
+    strapi.contentAPI.addQueryParams({
+      pLevel: { schema: (z) => z.string().max(3).optional() },
+    });
+  },
 };

--- a/server/index.js
+++ b/server/index.js
@@ -9,7 +9,7 @@ module.exports = {
   register: ({ strapi }) => {
     strapi.contentAPI.addQueryParams({
       pLevel: { schema: (z) => z.string().max(3).optional() },
-      pIgnore: { schema: (z) => z.union([z.string(), z.array(z.string())]).optional() },
+      pIgnore: { schema: (z) => z.string().optional() },
     });
   },
 };

--- a/server/index.js
+++ b/server/index.js
@@ -9,6 +9,7 @@ module.exports = {
   register: ({ strapi }) => {
     strapi.contentAPI.addQueryParams({
       pLevel: { schema: (z) => z.string().max(3).optional() },
+      pIgnore: { schema: (z) => z.union([z.string(), z.array(z.string())]).optional() },
     });
   },
 };

--- a/server/index.js
+++ b/server/index.js
@@ -7,9 +7,12 @@ module.exports = {
   bootstrap,
   config,
   register: ({ strapi }) => {
-    strapi.contentAPI.addQueryParams({
-      pLevel: { schema: (z) => z.string().max(3).optional() },
-      pIgnore: { schema: (z) => z.string().optional() },
-    });
+    // addQueryParams was introduced in Strapi 5.37 — skip gracefully on older versions
+    if (typeof strapi.contentAPI?.addQueryParams === 'function') {
+      strapi.contentAPI.addQueryParams({
+        pLevel: { schema: (z) => z.string().max(3).optional() },
+        pIgnore: { schema: (z) => z.string().optional() },
+      });
+    }
   },
 };


### PR DESCRIPTION
Self-referential relations (localizations) were being skipped because
the model's collectionName was already in the ignore list by the time
the localizations key was reached. Handle localizations before the
ignore check and populate it shallowly (true) to avoid infinite recursion.

Closes #21